### PR TITLE
Scrape GitHub trending

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TrendSpire
 
-TrendSpire automatically fetches GitHub trending repositories and generates a markdown digest. A GitHub Action keeps the `TRENDING.md` file updated on a daily schedule.
+TrendSpire scrapes GitHub's trending page and generates a markdown digest of popular repositories. A GitHub Action keeps the `TRENDING.md` file updated on a daily schedule.
 
 ## Getting Started
 

--- a/TRENDING.md
+++ b/TRENDING.md
@@ -1,9 +1,54 @@
 # 📈 GitHub Trending - Daily
 
-_Last updated: 2025-06-06 06:29 UTC_
+_Last updated: 2025-06-06 06:36 UTC_
 
 
-## [octocat/Hello-World](https://github.com/octocat/Hello-World)
-⭐ 0  •  📝 Unknown
-Fallback repo when trending API is unavailable.
+## [frdel/agent-zero](https://github.com/frdel/agent-zero)
+⭐ 8913  •  📝 Python
+Agent Zero AI framework
+
+
+## [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader)
+⭐ 7981  •  📝 Python
+A high-performance algorithmic trading platform and event-driven backtester
+
+
+## [scrapy/scrapy](https://github.com/scrapy/scrapy)
+⭐ 56214  •  📝 Python
+Scrapy, a fast high-level web crawling & scraping framework for Python.
+
+
+## [onlook-dev/onlook](https://github.com/onlook-dev/onlook)
+⭐ 16729  •  📝 TypeScript
+The Cursor for Designers • An Open-Source Visual Vibecoding Editor • Visually build, style, and edit your React App with AI
+
+
+## [Anduin2017/HowToCook](https://github.com/Anduin2017/HowToCook)
+⭐ 88042  •  📝 Dockerfile
+程序员在家做饭方法指南。Programmer's guide about how to cook at home (Simplified Chinese only).
+
+
+## [netbirdio/netbird](https://github.com/netbirdio/netbird)
+⭐ 14179  •  📝 Go
+Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls.
+
+
+## [iamgio/quarkdown](https://github.com/iamgio/quarkdown)
+⭐ 4578  •  📝 Kotlin
+🪐 Markdown with superpowers — from ideas to presentations, articles and books.
+
+
+## [TapXWorld/ChinaTextbook](https://github.com/TapXWorld/ChinaTextbook)
+⭐ 36498  •  📝 Roff
+所有小初高、大学PDF教材。
+
+
+## [ArduPilot/ardupilot](https://github.com/ArduPilot/ardupilot)
+⭐ 12617  •  📝 C++
+ArduPlane, ArduCopter, ArduRover, ArduSub source
+
+
+## [topoteretes/cognee](https://github.com/topoteretes/cognee)
+⭐ 3019  •  📝 Python
+Memory for AI Agents in 5 lines of code
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 Jinja2
+beautifulsoup4


### PR DESCRIPTION
## Summary
- scrape GitHub trending page with BeautifulSoup
- document scraping approach
- include BeautifulSoup as dependency
- regenerate trending digest

## Testing
- `pip install -r requirements.txt`
- `python -m src.render_digest`

------
https://chatgpt.com/codex/tasks/task_e_68428c0fd6e08330aedf57fd1c1f61bb