### PR TITLE
Improve trending digest presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
+<!-- TRENDING_START -->
+# 📈 GitHub Trending - Daily
+
+_Last updated: 2025-06-06 06:49 UTC_
+
+| Repository | ⭐ Stars | Language | Description |
+|------------|--------:|----------|-------------|
+
+| [frdel/agent-zero](https://github.com/frdel/agent-zero) | 8917 | Python | Agent Zero AI framework |
+
+| [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader) | 7982 | Python | A high-performance algorithmic trading platform and event-driven backtester |
+
+| [scrapy/scrapy](https://github.com/scrapy/scrapy) | 56218 | Python | Scrapy, a fast high-level web crawling & scraping framework for Python. |
+
+| [onlook-dev/onlook](https://github.com/onlook-dev/onlook) | 16738 | TypeScript | The Cursor for Designers • An Open-Source Visual Vibecoding Editor • Visually build, style, and edit your React App with AI |
+
+| [Anduin2017/HowToCook](https://github.com/Anduin2017/HowToCook) | 88045 | Dockerfile | 程序员在家做饭方法指南。Programmer's guide about how to cook at home (Simplified Chinese only). |
+
+| [netbirdio/netbird](https://github.com/netbirdio/netbird) | 14181 | Go | Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls. |
+
+| [iamgio/quarkdown](https://github.com/iamgio/quarkdown) | 4590 | Kotlin | 🪐 Markdown with superpowers — from ideas to presentations, articles and books. |
+
+| [TapXWorld/ChinaTextbook](https://github.com/TapXWorld/ChinaTextbook) | 36510 | Roff | 所有小初高、大学PDF教材。 |
+
+| [ArduPilot/ardupilot](https://github.com/ArduPilot/ardupilot) | 12618 | C++ | ArduPlane, ArduCopter, ArduRover, ArduSub source |
+
+| [topoteretes/cognee](https://github.com/topoteretes/cognee) | 3025 | Python | Memory for AI Agents in 5 lines of code |
+<!-- TRENDING_END -->
+
 # TrendSpire
 
 TrendSpire scrapes GitHub's trending page and generates a markdown digest of popular repositories. A GitHub Action keeps the `TRENDING.md` file updated on a daily schedule.

--- a/TRENDING.md
+++ b/TRENDING.md
@@ -1,54 +1,26 @@
 # 📈 GitHub Trending - Daily
 
-_Last updated: 2025-06-06 06:42 UTC_
+_Last updated: 2025-06-06 06:49 UTC_
 
+| Repository | ⭐ Stars | Language | Description |
+|------------|--------:|----------|-------------|
 
-## [frdel/agent-zero](https://github.com/frdel/agent-zero)
-⭐ 8916  •  📝 Python
-Agent Zero AI framework
+| [frdel/agent-zero](https://github.com/frdel/agent-zero) | 8917 | Python | Agent Zero AI framework |
 
+| [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader) | 7982 | Python | A high-performance algorithmic trading platform and event-driven backtester |
 
-## [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader)
-⭐ 7981  •  📝 Python
-A high-performance algorithmic trading platform and event-driven backtester
+| [scrapy/scrapy](https://github.com/scrapy/scrapy) | 56218 | Python | Scrapy, a fast high-level web crawling & scraping framework for Python. |
 
+| [onlook-dev/onlook](https://github.com/onlook-dev/onlook) | 16738 | TypeScript | The Cursor for Designers • An Open-Source Visual Vibecoding Editor • Visually build, style, and edit your React App with AI |
 
-## [scrapy/scrapy](https://github.com/scrapy/scrapy)
-⭐ 56214  •  📝 Python
-Scrapy, a fast high-level web crawling & scraping framework for Python.
+| [Anduin2017/HowToCook](https://github.com/Anduin2017/HowToCook) | 88045 | Dockerfile | 程序员在家做饭方法指南。Programmer's guide about how to cook at home (Simplified Chinese only). |
 
+| [netbirdio/netbird](https://github.com/netbirdio/netbird) | 14181 | Go | Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls. |
 
-## [onlook-dev/onlook](https://github.com/onlook-dev/onlook)
-⭐ 16734  •  📝 TypeScript
-The Cursor for Designers • An Open-Source Visual Vibecoding Editor • Visually build, style, and edit your React App with AI
+| [iamgio/quarkdown](https://github.com/iamgio/quarkdown) | 4590 | Kotlin | 🪐 Markdown with superpowers — from ideas to presentations, articles and books. |
 
+| [TapXWorld/ChinaTextbook](https://github.com/TapXWorld/ChinaTextbook) | 36510 | Roff | 所有小初高、大学PDF教材。 |
 
-## [Anduin2017/HowToCook](https://github.com/Anduin2017/HowToCook)
-⭐ 88043  •  📝 Dockerfile
-程序员在家做饭方法指南。Programmer's guide about how to cook at home (Simplified Chinese only).
+| [ArduPilot/ardupilot](https://github.com/ArduPilot/ardupilot) | 12618 | C++ | ArduPlane, ArduCopter, ArduRover, ArduSub source |
 
-
-## [netbirdio/netbird](https://github.com/netbirdio/netbird)
-⭐ 14179  •  📝 Go
-Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls.
-
-
-## [iamgio/quarkdown](https://github.com/iamgio/quarkdown)
-⭐ 4583  •  📝 Kotlin
-🪐 Markdown with superpowers — from ideas to presentations, articles and books.
-
-
-## [TapXWorld/ChinaTextbook](https://github.com/TapXWorld/ChinaTextbook)
-⭐ 36501  •  📝 Roff
-所有小初高、大学PDF教材。
-
-
-## [ArduPilot/ardupilot](https://github.com/ArduPilot/ardupilot)
-⭐ 12617  •  📝 C++
-ArduPlane, ArduCopter, ArduRover, ArduSub source
-
-
-## [topoteretes/cognee](https://github.com/topoteretes/cognee)
-⭐ 3021  •  📝 Python
-Memory for AI Agents in 5 lines of code
-
+| [topoteretes/cognee](https://github.com/topoteretes/cognee) | 3025 | Python | Memory for AI Agents in 5 lines of code |

--- a/src/render_digest.py
+++ b/src/render_digest.py
@@ -21,7 +21,7 @@ def load_config() -> dict:
     return DEFAULT_CONFIG.copy()
 
 
-def render_trending():
+def render_trending() -> str:
     config = load_config()
     repos = fetch_trending(
         language=config.get("language", ""),
@@ -41,6 +41,30 @@ def render_trending():
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(markdown)
 
+    return markdown
+
+
+def update_readme(trending_md: str) -> None:
+    """Insert the trending digest at the top of README between markers."""
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    readme_path = os.path.join(repo_root, "README.md")
+    start = "<!-- TRENDING_START -->"
+    end = "<!-- TRENDING_END -->"
+
+    with open(readme_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    if start in content and end in content:
+        pre, _start, rest = content.partition(start)
+        _mid, _end, post = rest.partition(end)
+        new_content = pre + start + "\n" + trending_md.strip() + "\n" + end + post
+    else:
+        new_content = start + "\n" + trending_md.strip() + "\n" + end + "\n" + content
+
+    with open(readme_path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+
 
 if __name__ == "__main__":
-    render_trending()
+    md = render_trending()
+    update_readme(md)

--- a/src/templates/trending.j2
+++ b/src/templates/trending.j2
@@ -2,9 +2,8 @@
 
 _Last updated: {{ timestamp }}_
 
+| Repository | ⭐ Stars | Language | Description |
+|------------|--------:|----------|-------------|
 {% for repo in repos %}
-## [{{ repo.full_name }}]({{ repo.url }})
-⭐ {{ repo.stars }}  •  📝 {{ repo.language }}
-{{ repo.description or "No description provided." }}
-
+| [{{ repo.full_name }}]({{ repo.url }}) | {{ repo.stars }} | {{ repo.language }} | {{ repo.description or "No description provided." }} |
 {% endfor %}


### PR DESCRIPTION
## Summary
- prettify trending Markdown with a table
- embed trending digest at the top of the README
- add script helper to update README after generating the digest

## Testing
- `python -m pip install -r requirements.txt`
- `python -m src.render_digest`

------
https://chatgpt.com/codex/tasks/task_e_68428f27ef2c8330b658a2d3a911c35d