### PR TITLE
Add OpenAI API usage logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 venv/
 .env
+logs/

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 <!-- TRENDING_START -->
 # 📈 GitHub Trending - Daily
 
-_Last updated: 2025-06-06 06:49 UTC_
+_Last updated: 2025-06-06 07:31 UTC_
 
 | Repository | ⭐ Stars | Language | Description |
 |------------|--------:|----------|-------------|
 
-| [frdel/agent-zero](https://github.com/frdel/agent-zero) | 8917 | Python | Agent Zero AI framework |
+| [frdel/agent-zero](https://github.com/frdel/agent-zero) | 8934 | Python | Agent Zero AI framework |
 
-| [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader) | 7982 | Python | A high-performance algorithmic trading platform and event-driven backtester |
+| [nautechsystems/nautilus_trader](https://github.com/nautechsystems/nautilus_trader) | 8005 | Python | A high-performance algorithmic trading platform and event-driven backtester |
 
-| [scrapy/scrapy](https://github.com/scrapy/scrapy) | 56218 | Python | Scrapy, a fast high-level web crawling & scraping framework for Python. |
+| [scrapy/scrapy](https://github.com/scrapy/scrapy) | 56232 | Python | Scrapy, a fast high-level web crawling & scraping framework for Python. |
 
-| [onlook-dev/onlook](https://github.com/onlook-dev/onlook) | 16738 | TypeScript | The Cursor for Designers • An Open-Source Visual Vibecoding Editor • Visually build, style, and edit your React App with AI |
+| [onlook-dev/onlook](https://github.com/onlook-dev/onlook) | 16756 | TypeScript | The Cursor for Designers • An Open-Source Visual Vibecoding Editor • Visually build, style, and edit your React App with AI |
 
-| [Anduin2017/HowToCook](https://github.com/Anduin2017/HowToCook) | 88045 | Dockerfile | 程序员在家做饭方法指南。Programmer's guide about how to cook at home (Simplified Chinese only). |
+| [Anduin2017/HowToCook](https://github.com/Anduin2017/HowToCook) | 88068 | Dockerfile | 程序员在家做饭方法指南。Programmer's guide about how to cook at home (Simplified Chinese only). |
 
-| [netbirdio/netbird](https://github.com/netbirdio/netbird) | 14181 | Go | Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls. |
+| [netbirdio/netbird](https://github.com/netbirdio/netbird) | 14190 | Go | Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls. |
 
-| [iamgio/quarkdown](https://github.com/iamgio/quarkdown) | 4590 | Kotlin | 🪐 Markdown with superpowers — from ideas to presentations, articles and books. |
+| [iamgio/quarkdown](https://github.com/iamgio/quarkdown) | 4623 | Kotlin | 🪐 Markdown with superpowers — from ideas to presentations, articles and books. |
 
-| [TapXWorld/ChinaTextbook](https://github.com/TapXWorld/ChinaTextbook) | 36510 | Roff | 所有小初高、大学PDF教材。 |
+| [TapXWorld/ChinaTextbook](https://github.com/TapXWorld/ChinaTextbook) | 36540 | Roff | 所有小初高、大学PDF教材。 |
 
-| [ArduPilot/ardupilot](https://github.com/ArduPilot/ardupilot) | 12618 | C++ | ArduPlane, ArduCopter, ArduRover, ArduSub source |
+| [ArduPilot/ardupilot](https://github.com/ArduPilot/ardupilot) | 12627 | C++ | ArduPlane, ArduCopter, ArduRover, ArduSub source |
 
-| [topoteretes/cognee](https://github.com/topoteretes/cognee) | 3025 | Python | Memory for AI Agents in 5 lines of code |
+| [topoteretes/cognee](https://github.com/topoteretes/cognee) | 3037 | Python | Memory for AI Agents in 5 lines of code |
 <!-- TRENDING_END -->
 
 # TrendSpire
@@ -90,3 +90,12 @@ manages daily and weekly runs:
 Token usage and cost for each run are appended to `codex_costs.csv`. Detailed logs are
 stored in the `codex_logs/` directory and uploaded as workflow artifacts. The daily job
 runs at 02:00 UTC and the weekly job every Sunday at 03:00 UTC.
+
+### API usage logs
+
+OpenAI API usage from the Codex runs is also written to `logs/api_usage.csv`. Each entry records the timestamp, model, token counts and cost in USD. To see a quick summary grouped by model run:
+
+```bash
+python scripts/summarize_usage.py
+```
+

--- a/scripts/summarize_usage.py
+++ b/scripts/summarize_usage.py
@@ -1,0 +1,24 @@
+import csv
+import os
+from collections import defaultdict
+
+LOG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'logs', 'api_usage.csv')
+
+def main() -> None:
+    usage = defaultdict(lambda: {'prompt': 0, 'completion': 0, 'cost': 0.0})
+    if not os.path.exists(LOG_FILE):
+        print('No API usage log found.')
+        return
+    with open(LOG_FILE, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            model = row['model']
+            usage[model]['prompt'] += int(row['prompt_tokens'])
+            usage[model]['completion'] += int(row['completion_tokens'])
+            usage[model]['cost'] += float(row['cost_usd'])
+    for model, stats in usage.items():
+        total_tokens = stats['prompt'] + stats['completion']
+        print(f"Model: {model}\n  Prompt tokens: {stats['prompt']}\n  Completion tokens: {stats['completion']}\n  Total tokens: {total_tokens}\n  Cost: ${stats['cost']:.6f}\n")
+
+if __name__ == '__main__':
+    main()

--- a/src/api_logger.py
+++ b/src/api_logger.py
@@ -1,0 +1,23 @@
+import csv
+import os
+from datetime import datetime
+
+LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "logs")
+USAGE_FILE = os.path.join(LOG_DIR, "api_usage.csv")
+
+
+def ensure_log_dir() -> None:
+    os.makedirs(LOG_DIR, exist_ok=True)
+    if not os.path.exists(USAGE_FILE):
+        with open(USAGE_FILE, "w", encoding="utf-8", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["timestamp", "service", "model", "prompt_tokens", "completion_tokens", "cost_usd"])
+
+
+def log_openai_usage(model: str, prompt_tokens: int, completion_tokens: int, cost: float) -> None:
+    """Append an OpenAI API usage entry to the CSV log."""
+    ensure_log_dir()
+    timestamp = datetime.utcnow().isoformat()
+    with open(USAGE_FILE, "a", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([timestamp, "openai", model, prompt_tokens, completion_tokens, f"{cost:.6f}"])

--- a/trendspire_codex_mixed.py
+++ b/trendspire_codex_mixed.py
@@ -12,6 +12,8 @@ from dotenv import load_dotenv
 import openai
 import tiktoken
 
+from src.api_logger import log_openai_usage
+
 LOG_DIR = "codex_logs"
 COST_LOG = "codex_costs.csv"
 
@@ -106,6 +108,7 @@ def daily_run() -> None:
     snippet = "\n".join(diff_response.splitlines()[:20])
     write_summary(summary_path, DAILY_MODEL, "daily", (prompt_tokens, completion_tokens), cost, test_proc.stdout, snippet)
     append_cost(timestamp, "daily", (prompt_tokens, completion_tokens), DAILY_MODEL, cost)
+    log_openai_usage(DAILY_MODEL, prompt_tokens, completion_tokens, cost)
 
     if test_proc.returncode == 0:
         branch = f"codex-daily-{timestamp}"
@@ -171,6 +174,7 @@ def weekly_run() -> None:
     snippet = "\n".join(diff_response.splitlines()[:20])
     write_summary(summary_path, WEEKLY_MODEL, "weekly", (prompt_tokens, completion_tokens), cost, test_proc.stdout, snippet)
     append_cost(timestamp, "weekly", (prompt_tokens, completion_tokens), WEEKLY_MODEL, cost)
+    log_openai_usage(WEEKLY_MODEL, prompt_tokens, completion_tokens, cost)
 
     if test_proc.returncode == 0:
         branch = f"codex-weekly-{timestamp}"


### PR DESCRIPTION
## Summary
- track OpenAI API usage in a new `logs/api_usage.csv`
- call the logger during daily and weekly Codex runs
- provide helper script `scripts/summarize_usage.py` to show total tokens and cost
- document API usage logging in README
- ignore the `logs/` directory in git

## Testing
- `pip install -r requirements.txt`
- `python -m src.render_digest` *(generates TRENDING.md)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684298bb28dc8330a1c7c0f404c26ada