### PR TITLE
Fix deprecated artifact action

### DIFF
--- a/.github/workflows/auto_codex_mixed.yml
+++ b/.github/workflows/auto_codex_mixed.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload Codex Logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: codex-logs
           path: codex_logs/


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to v4 in CI workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429da593cc8330b67369e96c9aebcd