### PR TITLE
Fix openai API compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 requests
 Jinja2
 beautifulsoup4
-openai
+openai>=1.84.0
 tiktoken
+pytest
+ghapi
 python-dotenv

--- a/trendspire_codex_mixed.py
+++ b/trendspire_codex_mixed.py
@@ -17,13 +17,13 @@ try:
 except ImportError:
     pass
 
-import openai
+from openai import OpenAI
 import tiktoken
 
 api_key = os.getenv("OPENAI_API_KEY")
 if not api_key:
     raise RuntimeError("OPENAI_API_KEY not set in environment")
-openai.api_key = api_key
+client = OpenAI(api_key=api_key)
 
 from src.api_logger import log_openai_usage
 
@@ -93,7 +93,10 @@ def daily_run() -> None:
     prompt_tokens = count_tokens(prompt, DAILY_MODEL)
 
     try:
-        response = openai.ChatCompletion.create(model=DAILY_MODEL, messages=[{"role": "user", "content": prompt}])
+        response = client.chat.completions.create(
+            model=DAILY_MODEL,
+            messages=[{"role": "user", "content": prompt}],
+        )
         diff_response = response.choices[0].message.content
     except Exception as exc:
         print(f"OpenAI API error: {exc}", file=sys.stderr)
@@ -158,7 +161,12 @@ def weekly_run() -> None:
 
     prompt_tokens = count_tokens(prompt, WEEKLY_MODEL)
     try:
-        response = openai.Completion.create(engine=WEEKLY_MODEL, prompt=prompt, max_tokens=3000, temperature=0.2)
+        response = client.completions.create(
+            model=WEEKLY_MODEL,
+            prompt=prompt,
+            max_tokens=3000,
+            temperature=0.2,
+        )
         diff_response = response.choices[0].text
     except Exception as exc:
         print(f"OpenAI API error: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- migrate `trendspire_codex_mixed.py` to OpenAI SDK v1
- update deps to use `openai>=1.84.0` and testing tools

## Testing
- `pip install -r requirements.txt`
- `OPENAI_API_KEY="sk-invalid" python trendspire_codex_mixed.py --mode daily` *(fails: incorrect API key and missing remote)*

------
https://chatgpt.com/codex/tasks/task_e_68429ef5f3e0833097bc291911b48520