### PR TITLE
Fix Codex dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 requests
 Jinja2
 beautifulsoup4
-openai>=1.84.0
+# Minimum compatible OpenAI client version
+openai>=1.8.4
 tiktoken
 pytest
 ghapi


### PR DESCRIPTION
## Summary
- correct the minimum OpenAI client version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842a2d3f5708330b18a9df11dfd7a02