### PR TITLE
Fix digest push on rebase conflict

### DIFF
--- a/.github/workflows/update_digest.yml
+++ b/.github/workflows/update_digest.yml
@@ -37,6 +37,7 @@ jobs:
           if [[ -n "$(git status --porcelain)" ]]; then
             git add TRENDING.md
             git commit -m "chore: update TRENDING.md [skip ci]"
+            git pull --rebase origin main
             git push origin HEAD:main
           else
             echo "No changes to commit."


### PR DESCRIPTION
## Summary
- prevent push failures in digest workflow by rebasing before pushing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a8eb8b088330b5c50f2e28ccb6e8