### PR TITLE
Fix push race in digest workflow

### DIFF
--- a/.github/workflows/update_digest.yml
+++ b/.github/workflows/update_digest.yml
@@ -37,8 +37,9 @@ jobs:
           if [[ -n "$(git status --porcelain)" ]]; then
             git add TRENDING.md
             git commit -m "chore: update TRENDING.md [skip ci]"
-            git pull --rebase origin main
-            git push origin HEAD:main
+            git fetch origin main
+            git rebase origin/main || git merge origin/main
+            git push origin HEAD:main || git push --force-with-lease origin HEAD:main
           else
             echo "No changes to commit."
           fi


### PR DESCRIPTION
## Summary
- ensure `update_digest` workflow fetches & rebases before pushing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a9d8559c8330a07aa9edab5db445