### PR TITLE
Fix digest workflow push race

### DIFF
--- a/.github/workflows/update_digest.yml
+++ b/.github/workflows/update_digest.yml
@@ -34,12 +34,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git add TRENDING.md
-            git commit -m "chore: update TRENDING.md [skip ci]"
-            git fetch origin main
-            git rebase origin/main || git merge origin/main
-            git push origin HEAD:main || git push --force-with-lease origin HEAD:main
-          else
-            echo "No changes to commit."
-          fi
+          git add TRENDING.md
+          git commit -m "chore: update TRENDING.md [skip ci]" || echo "No changes to commit"
+          git pull --rebase origin main --autostash
+          git push origin main


### PR DESCRIPTION
## Summary
- streamline push logic in `update_digest.yml`
- use `--autostash` so rebases don't fail on unstaged changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842abbb00c08330982509ae99e8fb5b