### PR TITLE
feat: add mixed mode codex automation

### DIFF
--- a/trendspire_codex_mixed.py
+++ b/trendspire_codex_mixed.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -95,6 +96,189 @@ def append_cost(timestamp: str, run_type: str, tokens: tuple, model: str, cost: 
     prompt_tokens, completion_tokens = tokens
     with open(COST_LOG, "a", encoding="utf-8") as f:
         f.write(f"{timestamp},{run_type},{prompt_tokens},{completion_tokens},{model},{cost:.6f}\n")
+
+
+def get_analysis_prompt(file_path: str, code: str) -> str:
+    return f"""You are an expert code reviewer and GitHub automation assistant.
+Your job is to improve a Python project by analyzing a single file at a time.
+
+📁 File: `{file_path}`
+
+🔍 TASKS:
+1. Analyze the code in this file
+2. List key problems or improvements (bugs, readability, duplication, better structure, etc.)
+3. Suggest concrete changes with justification
+4. If useful, recommend creating/modifying tests or docs
+
+Please return:
+- ✅ Summary of issues
+- 🛠️ Suggested improvements (plain language)
+- 🧠 Rewritten code (modified version with changes applied)
+
+Here is the original file:
+```python
+{code}
+```
+"""
+
+
+def verify_and_finalize_prompt(original_code: str, suggested_code: str) -> str:
+    return f"""You previously reviewed this code:
+
+Original:
+```python
+{original_code}
+```
+Suggested Rewrite:
+```python
+{suggested_code}
+```
+✅ Please double-check the rewritten code.
+
+Does it preserve original functionality?
+
+Are the improvements meaningful?
+
+Is it production-safe and PEP8 compliant?
+
+Return ONLY the finalized updated version.
+"""
+
+
+def get_pr_message_prompt(suggestions_summary: str, file_list: list[str]) -> str:
+    files = '\n'.join(f"- `{f}`" for f in file_list)
+    return f"""You are a GitHub assistant preparing an automated Pull Request.
+
+📝 TASK:
+Summarize the improvements made across these files:
+{files}
+
+💡 Use this suggestion summary as context:
+{suggestions_summary}
+
+Please write a clear:
+1. PR Title
+2. PR Body
+(Include why the change matters, any risks, and that it was auto-generated)
+
+Format:
+Title: <your title here>
+Body:
+<your detailed PR message here>
+"""
+
+
+def get_log_summary_prompt(file_path: str, issues: str, new_code: str) -> str:
+    return f"""You are a GitHub automation logger.
+
+Please create a compact summary for today's automated suggestion for:
+📄 File: `{file_path}`
+
+🪲 Issues Identified:
+{issues}
+
+✅ Rewritten Code:
+```python
+{new_code}
+```
+📦 Format the summary in plain markdown for a changelog file or commit message.
+"""
+
+
+def extract_code_block(text: str) -> str:
+    match = re.search(r"```python\n(.*?)```", text, re.DOTALL)
+    return match.group(1).strip() if match else ""
+
+
+def extract_summary(text: str) -> str:
+    code_match = re.search(r"```python\n.*?```", text, re.DOTALL)
+    if code_match:
+        return text[: code_match.start()].strip()
+    return text.strip()
+
+
+def get_target_files(root: str):
+    for r, _dirs, names in os.walk(root):
+        for name in names:
+            if name.endswith(".py"):
+                yield os.path.join(r, name)
+
+
+def mixed_run() -> None:
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    branch = f"codex-mixed-{timestamp}"
+    subprocess.run(["git", "checkout", "-b", branch], check=True)
+
+    summaries: list[str] = []
+    changed_files: list[str] = []
+
+    for path in get_target_files(SOURCE_DIR):
+        with open(path, "r", encoding="utf-8") as f:
+            original_code = f.read()
+
+        prompt = get_analysis_prompt(path, original_code)
+        try:
+            response = client.chat.completions.create(
+                model=WEEKLY_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            analysis_text = response.choices[0].message.content
+        except OpenAIError as exc:
+            print(exc, file=sys.stderr)
+            continue
+
+        new_code = extract_code_block(analysis_text)
+        summary = extract_summary(analysis_text)
+
+        if new_code and new_code != original_code:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(new_code)
+            changed_files.append(path)
+            summaries.append(summary)
+
+            log_path = os.path.join(LOG_DIR, f"mixed_{timestamp}.md")
+            with open(log_path, "a", encoding="utf-8") as logf:
+                logf.write(get_log_summary_prompt(path, summary, new_code))
+                logf.write("\n")
+
+    if not changed_files:
+        print("No changes produced", file=sys.stderr)
+        return
+
+    try:
+        run_cmd(["pytest"])
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return
+
+    subprocess.run(["git", "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"chore: codex mixed improvements {timestamp}"],
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", branch], check=False)
+
+    pr_prompt = get_pr_message_prompt("\n".join(summaries), changed_files)
+    try:
+        pr_resp = client.chat.completions.create(
+            model=DAILY_MODEL,
+            messages=[{"role": "user", "content": pr_prompt}],
+        )
+        pr_text = pr_resp.choices[0].message.content
+    except OpenAIError as exc:
+        print(exc, file=sys.stderr)
+        return
+
+    title = "Codex Improvements"
+    body = pr_text.strip()
+    for line in pr_text.splitlines():
+        if line.lower().startswith("title:"):
+            title = line.split("Title:", 1)[1].strip()
+        elif line.lower().startswith("body:"):
+            body = pr_text.split("Body:", 1)[1].strip()
+            break
+
+    run_cmd(["gh", "pr", "create", "--title", title, "--body", body])
 
 
 def daily_run() -> None:
@@ -295,17 +479,22 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run Codex automations")
     parser.add_argument(
         "--mode",
-        choices=["daily", "weekly"],
+        choices=["daily", "weekly", "mixed"],
         required=True,
-        help="Choose 'daily' for diff-only runs or 'weekly' for full-repo runs."
+        help=(
+            "Choose 'daily' for diff-only runs, 'weekly' for full-repo runs, or '"
+            "mixed' for per-file analysis"
+        ),
     )
     args = parser.parse_args()
     ensure_logs()
 
     if args.mode == "daily":
         daily_run()
-    else:
+    elif args.mode == "weekly":
         weekly_run()
+    else:
+        mixed_run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support a new `mixed` mode in `trendspire_codex_mixed.py`
- add functions for GPT prompts and utilities
- implement `mixed_run` for per-file AI refactoring
- update CLI to select the new mode

## Testing
- `python -m py_compile trendspire_codex_mixed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bac3d8888330ad61eb73c9a9390a