### PR TITLE
Add flexible API log formats

### DIFF
--- a/.github/workflows/auto_codex_mixed.yml
+++ b/.github/workflows/auto_codex_mixed.yml
@@ -94,3 +94,13 @@ jobs:
         with:
           name: codex-memory
           path: trendspire_memory/
+
+      - name: Commit and push API logs
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add logs/api_usage.* || true
+          git commit -m "chore: update API usage logs [skip ci]" || echo "No changes to commit"
+          git pull --rebase origin main --autostash
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -99,4 +99,6 @@ python trendspire_autoloop.py --mode daily   # or weekly
 
 ### API usage reports
 
-The file `logs/api_usage.csv` records model token counts and cost. Use `python scripts/summarize_usage.py` for a quick summary grouped by model.
+The file `logs/api_usage.*` records token counts and cost. Set `API_LOG_FORMAT`
+to `csv`, `json` or `txt` to control the format. Run `python
+scripts/summarize_usage.py` for a quick summary grouped by model.

--- a/scripts/summarize_usage.py
+++ b/scripts/summarize_usage.py
@@ -1,21 +1,43 @@
 import csv
+import json
 import os
 from collections import defaultdict
 
-LOG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'logs', 'api_usage.csv')
+LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'logs')
+LOG_FORMAT = os.getenv('API_LOG_FORMAT', 'csv').lower()
+LOG_FILE = os.path.join(LOG_DIR, f'api_usage.{LOG_FORMAT}')
 
 def main() -> None:
     usage = defaultdict(lambda: {'prompt': 0, 'completion': 0, 'cost': 0.0})
     if not os.path.exists(LOG_FILE):
         print('No API usage log found.')
         return
-    with open(LOG_FILE, 'r', encoding='utf-8') as f:
-        reader = csv.DictReader(f)
-        for row in reader:
+    if LOG_FORMAT == 'csv':
+        with open(LOG_FILE, 'r', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                model = row['model']
+                usage[model]['prompt'] += int(row['prompt_tokens'])
+                usage[model]['completion'] += int(row['completion_tokens'])
+                usage[model]['cost'] += float(row['cost_usd'])
+    elif LOG_FORMAT == 'json':
+        with open(LOG_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        for row in data:
             model = row['model']
             usage[model]['prompt'] += int(row['prompt_tokens'])
             usage[model]['completion'] += int(row['completion_tokens'])
             usage[model]['cost'] += float(row['cost_usd'])
+    else:  # txt
+        with open(LOG_FILE, 'r', encoding='utf-8') as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) != 6:
+                    continue
+                _, _service, model, prompt, completion, cost = parts
+                usage[model]['prompt'] += int(prompt)
+                usage[model]['completion'] += int(completion)
+                usage[model]['cost'] += float(cost)
     for model, stats in usage.items():
         total_tokens = stats['prompt'] + stats['completion']
         print(f"Model: {model}\n  Prompt tokens: {stats['prompt']}\n  Completion tokens: {stats['completion']}\n  Total tokens: {total_tokens}\n  Cost: ${stats['cost']:.6f}\n")

--- a/src/api_logger.py
+++ b/src/api_logger.py
@@ -1,23 +1,70 @@
 import csv
+import json
 import os
 from datetime import datetime
 
 LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "logs")
-USAGE_FILE = os.path.join(LOG_DIR, "api_usage.csv")
+LOG_FORMAT = os.getenv("API_LOG_FORMAT", "csv").lower()
+USAGE_FILE = os.path.join(LOG_DIR, f"api_usage.{LOG_FORMAT}")
 
 
 def ensure_log_dir() -> None:
     os.makedirs(LOG_DIR, exist_ok=True)
     if not os.path.exists(USAGE_FILE):
-        with open(USAGE_FILE, "w", encoding="utf-8", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow(["timestamp", "service", "model", "prompt_tokens", "completion_tokens", "cost_usd"])
+        if LOG_FORMAT == "csv":
+            with open(USAGE_FILE, "w", encoding="utf-8", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    "timestamp",
+                    "service",
+                    "model",
+                    "prompt_tokens",
+                    "completion_tokens",
+                    "cost_usd",
+                ])
+        elif LOG_FORMAT == "json":
+            with open(USAGE_FILE, "w", encoding="utf-8") as f:
+                json.dump([], f)
+        else:  # txt
+            open(USAGE_FILE, "w", encoding="utf-8").close()
 
 
 def log_openai_usage(model: str, prompt_tokens: int, completion_tokens: int, cost: float) -> None:
-    """Append an OpenAI API usage entry to the CSV log."""
+    """Append an OpenAI API usage entry in the selected format."""
     ensure_log_dir()
     timestamp = datetime.utcnow().isoformat()
-    with open(USAGE_FILE, "a", encoding="utf-8", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow([timestamp, "openai", model, prompt_tokens, completion_tokens, f"{cost:.6f}"])
+    entry = {
+        "timestamp": timestamp,
+        "service": "openai",
+        "model": model,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "cost_usd": float(f"{cost:.6f}"),
+    }
+    if LOG_FORMAT == "csv":
+        with open(USAGE_FILE, "a", encoding="utf-8", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                [
+                    entry["timestamp"],
+                    entry["service"],
+                    entry["model"],
+                    entry["prompt_tokens"],
+                    entry["completion_tokens"],
+                    entry["cost_usd"],
+                ]
+            )
+    elif LOG_FORMAT == "json":
+        with open(USAGE_FILE, "r+", encoding="utf-8") as f:
+            data = json.load(f)
+            data.append(entry)
+            f.seek(0)
+            json.dump(data, f, indent=2)
+            f.truncate()
+    else:  # txt
+        line = (
+            f"{entry['timestamp']} openai {entry['model']} {entry['prompt_tokens']} "
+            f"{entry['completion_tokens']} {entry['cost_usd']:.6f}\n"
+        )
+        with open(USAGE_FILE, "a", encoding="utf-8") as f:
+            f.write(line)

--- a/tests/test_api_logger.py
+++ b/tests/test_api_logger.py
@@ -1,0 +1,31 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module(tmp_path, fmt):
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / 'src' / 'api_logger.py'
+    spec = importlib.util.spec_from_file_location('api_logger', module_path)
+    api_logger = importlib.util.module_from_spec(spec)
+    # Set environment variable before loading
+    import os
+    os.environ['API_LOG_FORMAT'] = fmt
+    spec.loader.exec_module(api_logger)
+    api_logger.LOG_DIR = tmp_path
+    api_logger.USAGE_FILE = tmp_path / f"api_usage.{api_logger.LOG_FORMAT}"
+    return api_logger
+
+
+def test_log_openai_usage_json(tmp_path):
+    api_logger = _load_module(tmp_path, 'json')
+    api_logger.log_openai_usage('test-model', 1, 2, 0.001)
+    data = json.loads((tmp_path / 'api_usage.json').read_text())
+    assert data and data[0]['model'] == 'test-model'
+
+
+def test_log_openai_usage_txt(tmp_path):
+    api_logger = _load_module(tmp_path, 'txt')
+    api_logger.log_openai_usage('test-model', 3, 4, 0.123456)
+    content = (tmp_path / 'api_usage.txt').read_text()
+    assert 'test-model' in content

--- a/tests/test_summarize_usage.py
+++ b/tests/test_summarize_usage.py
@@ -1,0 +1,61 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module(tmp_path, fmt):
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / 'scripts' / 'summarize_usage.py'
+    spec = importlib.util.spec_from_file_location('summarize_usage', module_path)
+    mod = importlib.util.module_from_spec(spec)
+    import os
+    os.environ['API_LOG_FORMAT'] = fmt
+    spec.loader.exec_module(mod)
+    mod.LOG_DIR = tmp_path
+    mod.LOG_FILE = tmp_path / f"api_usage.{fmt}"
+    return mod
+
+
+def _create_log(tmp_path, fmt):
+    if fmt == 'csv':
+        (tmp_path / 'api_usage.csv').write_text(
+            'timestamp,service,model,prompt_tokens,completion_tokens,cost_usd\n'
+            't,openai,test,1,2,0.1\n'
+        )
+    elif fmt == 'json':
+        (tmp_path / 'api_usage.json').write_text(
+            json.dumps([{
+                'timestamp': 't', 'service': 'openai', 'model': 'test',
+                'prompt_tokens': 1, 'completion_tokens': 2, 'cost_usd': 0.1
+            }])
+        )
+    else:  # txt
+        (tmp_path / 'api_usage.txt').write_text(
+            't openai test 1 2 0.1\n'
+        )
+
+
+def _run_and_capture(mod, capsys):
+    mod.main()
+    return capsys.readouterr().out
+
+
+def test_summarize_usage_csv(tmp_path, capsys):
+    _create_log(tmp_path, 'csv')
+    mod = _load_module(tmp_path, 'csv')
+    out = _run_and_capture(mod, capsys)
+    assert 'test' in out
+
+
+def test_summarize_usage_json(tmp_path, capsys):
+    _create_log(tmp_path, 'json')
+    mod = _load_module(tmp_path, 'json')
+    out = _run_and_capture(mod, capsys)
+    assert 'test' in out
+
+
+def test_summarize_usage_txt(tmp_path, capsys):
+    _create_log(tmp_path, 'txt')
+    mod = _load_module(tmp_path, 'txt')
+    out = _run_and_capture(mod, capsys)
+    assert 'test' in out


### PR DESCRIPTION
## Summary
- allow `API_LOG_FORMAT` env var to control api log format (csv, json or txt)
- append OpenAI API usage in the selected format
- test JSON and TXT logging

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bcd72d748330a0b29a28c3feb72c