### PR TITLE
Add Codex Autobot tool

### DIFF
--- a/.github/workflows/autobot.yml
+++ b/.github/workflows/autobot.yml
@@ -1,0 +1,28 @@
+name: Codex Autobot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  run-autobot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt gh
+      - name: Run Codex Autobot
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python codex_autobot.py

--- a/codex_autobot.py
+++ b/codex_autobot.py
@@ -1,0 +1,155 @@
+import argparse
+import logging
+import os
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable
+
+from openai import OpenAI
+
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+LOG_DIR = Path("codex_logs")
+LOG_DIR.mkdir(exist_ok=True)
+
+
+logging.basicConfig(
+    filename=LOG_DIR / f"log_{datetime.utcnow().isoformat()}.txt",
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+
+
+def get_analysis_prompt(file_path: str, code: str) -> str:
+    language = Path(file_path).suffix.lstrip(".") or "text"
+    return f"""You are an expert code reviewer and GitHub automation assistant.
+Your job is to improve a {language} project by analyzing a single file at a time.
+
+📁 File: `{file_path}`
+
+🔍 TASKS:
+1. Analyze the code in this file
+2. List key problems or improvements (bugs, readability, duplication, better structure, etc.)
+3. Suggest concrete changes with justification
+4. If useful, recommend creating/modifying tests or docs
+
+Please return:
+- ✅ Summary of issues
+- 🛠️ Suggested improvements (plain language)
+- 🧠 Rewritten code (modified version with changes applied)
+
+Here is the original file:
+```{language}
+{code}
+```"""
+
+
+def get_target_files(folder: str = "src", exts: Iterable[str] = ("py",), days: int | None = None, min_size: int = 0) -> list[str]:
+    """Return files under *folder* matching extensions and filters."""
+    cutoff = None
+    if days is not None:
+        cutoff = datetime.utcnow() - timedelta(days=days)
+    results: list[str] = []
+    for path in Path(folder).rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lstrip(".") not in exts:
+            continue
+        if path.name.startswith("_"):
+            continue
+        stat = path.stat()
+        if cutoff and datetime.utcfromtimestamp(stat.st_mtime) < cutoff:
+            continue
+        if stat.st_size < min_size:
+            continue
+        results.append(str(path))
+    return results
+
+
+def create_branch(branch_name: str) -> None:
+    subprocess.run(["git", "checkout", "-b", branch_name], check=True)
+
+
+def commit_and_push(file_paths: list[str], branch_name: str) -> None:
+    for f in file_paths:
+        subprocess.run(["git", "add", f], check=True)
+    subprocess.run(["git", "commit", "-m", f"Codex Bot: Improve {', '.join(file_paths)}"], check=True)
+    subprocess.run(["git", "push", "origin", branch_name], check=True)
+
+
+def create_pr(pr_title: str, pr_body: str) -> None:
+    subprocess.run([
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        "codex-bot",
+        "--title",
+        pr_title,
+        "--body",
+        pr_body,
+    ], check=True)
+
+
+def call_gpt(prompt: str) -> str:
+    logging.info("Calling OpenAI API...")
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Codex Autobot")
+    parser.add_argument("--extensions", "-e", nargs="+", default=["py"], help="File extensions to scan")
+    parser.add_argument("--days", type=int, default=None, help="Only files modified within N days")
+    parser.add_argument("--min-size", type=int, default=0, help="Skip files smaller than this size (bytes)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    modified_files: list[str] = []
+    pr_summary: list[str] = []
+
+    files = get_target_files("src", args.extensions, args.days, args.min_size)
+    if not files:
+        logging.info("No target files found.")
+        return
+
+    branch_name = "codex-bot"
+    create_branch(branch_name)
+
+    for file in files:
+        original_code = Path(file).read_text()
+        prompt = get_analysis_prompt(file, original_code)
+        result = call_gpt(prompt)
+
+        if "```" in result:
+            try:
+                new_code = result.split("```", 1)[1].split("```", 1)[0].strip()
+                if new_code != original_code:
+                    Path(file).write_text(new_code)
+                    modified_files.append(file)
+                    pr_summary.append(result.split("🛠️ Suggested improvements", 1)[-1].split("🧠 Rewritten code")[0].strip())
+                    logging.info(f"Updated file: {file}")
+            except Exception as exc:
+                logging.error(f"Error processing file {file}: {exc}")
+
+    if modified_files:
+        commit_and_push(modified_files, branch_name)
+        pr_title = "Codex Autobot Improvements"
+        pr_body = "\n".join(pr_summary)
+        create_pr(pr_title, pr_body)
+        logging.info("PR created successfully.")
+    else:
+        logging.info("No changes suggested.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_codex_autobot.py
+++ b/tests/test_codex_autobot.py
@@ -1,0 +1,39 @@
+import os
+import time
+from pathlib import Path
+
+import importlib.util
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'codex_autobot.py'
+spec = importlib.util.spec_from_file_location('autobot', MODULE_PATH)
+autobot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(autobot)
+
+
+def test_get_target_files_filters(tmp_path):
+    (tmp_path / 'a.py').write_text('print("a")')
+    (tmp_path / 'b.js').write_text('console.log("b")')
+    (tmp_path / 'c.txt').write_text('c')
+
+    files = autobot.get_target_files(tmp_path, exts=['py', 'js'])
+    assert len(files) == 2
+    assert any(f.endswith('a.py') for f in files)
+    assert any(f.endswith('b.js') for f in files)
+
+
+def test_get_target_files_time_and_size(tmp_path):
+    recent = tmp_path / 'recent.py'
+    old = tmp_path / 'old.py'
+    small = tmp_path / 'small.py'
+
+    recent.write_text('print("hi")')
+    old.write_text('print("old")')
+    small.write_text('x')
+
+    old_time = time.time() - 86400 * 5  # 5 days ago
+    os.utime(old, (old_time, old_time))
+
+    files = autobot.get_target_files(tmp_path, exts=['py'], days=2, min_size=2)
+    assert str(recent) in files
+    assert str(old) not in files
+    assert str(small) not in files


### PR DESCRIPTION
## Summary
- add a new `codex_autobot.py` script for per-file Codex refactoring
- allow filtering by file extension, modification time and size
- include an accompanying GitHub Actions workflow `autobot.yml`
- create unit tests for the new script

## Testing
- `OPENAI_API_KEY=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842baea40e08330a3af7542ff7bea25