### PR TITLE
Add type hints and docstring

### DIFF
--- a/src/fetch_trending.py
+++ b/src/fetch_trending.py
@@ -7,6 +7,8 @@ from bs4 import BeautifulSoup
 # Ensure project root is on ``sys.path`` when executed directly
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from typing import Any
+
 from utils import fetch_url, log_update
 
 
@@ -22,8 +24,8 @@ FALLBACK_REPO = {
 }
 
 
-def fetch_trending(language: str = "", since: str = "daily", limit: int = 25):
-    """Scrape GitHub Trending for a list of repositories."""
+def fetch_trending(language: str = "", since: str = "daily", limit: int = 25) -> list[dict[str, Any]]:
+    """Return trending repositories for the given language, period and limit."""
     url = BASE_URL
     if language:
         url = f"{BASE_URL}/{language}"


### PR DESCRIPTION
## Summary
- add typing import in `src/fetch_trending.py`
- specify return type on `fetch_trending`
- refine docstring with short description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435752f178833093f1631704909d21