### PR TITLE
Refactor trending code and add tests

### DIFF
--- a/ai_loop/codex_autobot.py
+++ b/ai_loop/codex_autobot.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import subprocess
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
 
@@ -48,7 +48,7 @@ def get_target_files(folder: str = "src", exts: Iterable[str] = ("py",), days: i
     """Return files under *folder* matching extensions and filters."""
     cutoff = None
     if days is not None:
-        cutoff = datetime.utcnow() - timedelta(days=days)
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     results: list[str] = []
     for path in Path(folder).rglob("*"):
         if not path.is_file():
@@ -58,7 +58,7 @@ def get_target_files(folder: str = "src", exts: Iterable[str] = ("py",), days: i
         if path.name.startswith("_"):
             continue
         stat = path.stat()
-        if cutoff and datetime.utcfromtimestamp(stat.st_mtime) < cutoff:
+        if cutoff and datetime.fromtimestamp(stat.st_mtime, timezone.utc) < cutoff:
             continue
         if stat.st_size < min_size:
             continue

--- a/src/render_digest.py
+++ b/src/render_digest.py
@@ -1,9 +1,8 @@
 import json
-import os
-from datetime import datetime
-from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
 
-from .fetch_trending import fetch_trending
+
+from .fetch_trending import fetch_trending, render_markdown, TEMPLATE_DIR
 
 
 DEFAULT_CONFIG = {
@@ -14,16 +13,15 @@ DEFAULT_CONFIG = {
 
 
 def load_config() -> dict:
-    """Load the trending scraper configuration from ``config.json``."""
-    cfg_path = os.path.join(os.path.dirname(__file__), "config.json")
-    if os.path.isfile(cfg_path):
-        with open(cfg_path, "r", encoding="utf-8") as f:
-            return json.load(f)
+    """Load trending scraper settings from ``config.json``."""
+    cfg_path = Path(__file__).parent / "config.json"
+    if cfg_path.is_file():
+        return json.loads(cfg_path.read_text(encoding="utf-8"))
     return DEFAULT_CONFIG.copy()
 
 
 def render_trending() -> str:
-    """Render the trending digest markdown and write ``TRENDING.md``."""
+    """Generate the trending digest and write ``TRENDING.md``."""
     config = load_config()
     repos = fetch_trending(
         language=config.get("language", ""),
@@ -31,30 +29,19 @@ def render_trending() -> str:
         limit=config.get("limit", 10),
     )
 
-    env = Environment(loader=FileSystemLoader(os.path.join(os.path.dirname(__file__), "templates")))
-    template = env.get_template("trending.j2")
-    markdown = template.render(
-        repos=repos,
-        since=config.get("since", "daily"),
-        timestamp=datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"),
-    )
-
-    output_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "TRENDING.md")
-    with open(output_path, "w", encoding="utf-8") as f:
-        f.write(markdown)
-
+    markdown = render_markdown(repos, config.get("since", "daily"))
+    out_path = Path(__file__).resolve().parent.parent / "TRENDING.md"
+    out_path.write_text(markdown, encoding="utf-8")
     return markdown
 
 
 def update_readme(trending_md: str) -> None:
     """Insert the trending digest at the top of README between markers."""
-    repo_root = os.path.dirname(os.path.dirname(__file__))
-    readme_path = os.path.join(repo_root, "README.md")
+    readme_path = Path(__file__).resolve().parent.parent / "README.md"
     start = "<!-- TRENDING_START -->"
     end = "<!-- TRENDING_END -->"
 
-    with open(readme_path, "r", encoding="utf-8") as f:
-        content = f.read()
+    content = readme_path.read_text(encoding="utf-8") if readme_path.exists() else ""
 
     if start in content and end in content:
         pre, _start, rest = content.partition(start)
@@ -63,8 +50,7 @@ def update_readme(trending_md: str) -> None:
     else:
         new_content = start + "\n" + trending_md.strip() + "\n" + end + "\n" + content
 
-    with open(readme_path, "w", encoding="utf-8") as f:
-        f.write(new_content)
+    readme_path.write_text(new_content, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,7 +6,7 @@ import difflib
 import os
 import shutil
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -33,7 +33,7 @@ def log_update(action: str, details: str) -> None:
     """Append a timestamped log entry describing an update."""
     LOG_DIR.mkdir(exist_ok=True)
     log_path = LOG_DIR / "update_log.txt"
-    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     with log_path.open("a", encoding="utf-8") as f:
         f.write(f"[{timestamp}] {action}: {details}\n")
 
@@ -42,7 +42,7 @@ def backup_file(filepath: str | Path) -> Path:
     """Copy *filepath* into ``backups/`` with a timestamp."""
     path = Path(filepath)
     BACKUP_DIR.mkdir(exist_ok=True)
-    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     dest = BACKUP_DIR / f"{path.stem}_{timestamp}{path.suffix}"
     shutil.copy2(path, dest)
     return dest

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -13,12 +13,15 @@ spec = importlib.util.spec_from_file_location(
     "fetch_trending", REPO_ROOT / "src" / "fetch_trending.py"
 )
 fetch_trending = importlib.util.module_from_spec(spec)
+import sys
+sys.modules[spec.name] = fetch_trending
 spec.loader.exec_module(fetch_trending)
 
 spec2 = importlib.util.spec_from_file_location(
     "ai_readme", REPO_ROOT / "ai_loop" / "ai_readme.py"
 )
 ai_readme = importlib.util.module_from_spec(spec2)
+sys.modules[spec2.name] = ai_readme
 spec2.loader.exec_module(ai_readme)
 
 

--- a/tests/test_fetch_trending.py
+++ b/tests/test_fetch_trending.py
@@ -2,9 +2,13 @@ import importlib.util
 import pathlib
 from unittest import mock
 
-MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / 'src' / 'fetch_trending.py'
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+import sys
+sys.path.insert(0, str(REPO_ROOT))
+MODULE_PATH = REPO_ROOT / 'src' / 'fetch_trending.py'
 spec = importlib.util.spec_from_file_location('fetch_trending', MODULE_PATH)
 ft = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = ft
 spec.loader.exec_module(ft)
 
 def test_fetch_trending_fallback_on_error():

--- a/tests/test_openai_helper.py
+++ b/tests/test_openai_helper.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+from pathlib import Path
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+spec = importlib.util.find_spec('src.openai_helper')
+openai_helper = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = openai_helper
+spec.loader.exec_module(openai_helper)
+
+class DummyResp:
+    def __init__(self, content):
+        self.choices = [type('Obj', (), {'message': type('Msg', (), {'content': content})})]
+        self.usage = type('U', (), {'total_tokens': 10, 'prompt_tokens': 5, 'completion_tokens':5})
+        self.choices[0].finish_reason = 'stop'
+
+class DummyClient:
+    def __init__(self):
+        self.chat = type('Chat', (), {'completions': type('Comp', (), {'create': lambda self, **k: DummyResp('hi')})()})()
+
+
+def test_get_client_missing_key(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    with pytest.raises(RuntimeError):
+        openai_helper._client = None
+        openai_helper._get_client()
+
+
+def test_ask_openai(monkeypatch):
+    monkeypatch.setattr(openai_helper, '_get_client', lambda: DummyClient())
+    result = openai_helper.ask_openai('prompt', model='gpt-3.5-turbo')
+    assert result == 'hi'
+


### PR DESCRIPTION
## Summary
- use dataclass for Repo and clean fetch_trending
- refactor render_digest to reuse render_markdown
- switch utilities to timezone-aware timestamps
- fix codex_autobot datetime use
- update tests for new import requirements
- add tests for openai_helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684364ef336c8330b3581b91199dd0fb