### PR TITLE
Add Codex pipeline helpers

### DIFF
--- a/.github/workflows/auto_codex_pipeline.yml
+++ b/.github/workflows/auto_codex_pipeline.yml
@@ -1,0 +1,65 @@
+name: Auto Codex Pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  codex_pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt gh
+
+      - name: Run prompt 1
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/run_prompt.py ai_prompts/01_refactor_and_reorg.md codex-step01-refactor-${{ github.run_id }}
+
+      - name: Run prompt 2
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/run_prompt.py ai_prompts/02_run_tests_and_fix.md codex-step02-tests-${{ github.run_id }}
+
+      - name: Run prompt 3
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/run_prompt.py ai_prompts/03_document_github_actions.md codex-step03-docs-${{ github.run_id }}
+
+      - name: Run prompt 4
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/run_prompt.py ai_prompts/04_enable_full_ai_loop.md codex-step04-enable-${{ github.run_id }}
+
+      - name: Run prompt 5
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/run_prompt.py ai_prompts/05_repo_overview.md codex-step05-overview-${{ github.run_id }}
+
+      - name: Run prompt 6
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/run_prompt.py ai_prompts/06_readme_sync_payload.json codex-step06-readme-${{ github.run_id }}
+
+      - name: Run prompt 7
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/run_prompt.py ai_prompts/07_contributing_and_usage_docs.md codex-step07-contrib-${{ github.run_id }}

--- a/ai_prompts/01_refactor_and_reorg.md
+++ b/ai_prompts/01_refactor_and_reorg.md
@@ -1,0 +1,1 @@
+Please move all Python modules into src/, group AI-loop scripts under ai_loop/, add type hints and docstrings, clean up unused imports, and output a single unified diff.

--- a/ai_prompts/02_run_tests_and_fix.md
+++ b/ai_prompts/02_run_tests_and_fix.md
@@ -1,0 +1,1 @@
+I just applied the refactor patch. Run pytest and fix any broken imports or signatures so that all tests pass. Give me a diff of only the changes needed to restore test green.

--- a/ai_prompts/03_document_github_actions.md
+++ b/ai_prompts/03_document_github_actions.md
@@ -1,0 +1,1 @@
+Explain in simple Markdown (2–4 paragraphs) how each workflow under .github/workflows/ works, what triggers it, and what files it changes.

--- a/ai_prompts/04_enable_full_ai_loop.md
+++ b/ai_prompts/04_enable_full_ai_loop.md
@@ -1,0 +1,1 @@
+Update auto_codex_mixed.yml and the AI loop script to run Codex on every push to main, apply patches, run tests, and open a PR if tests pass. Show me a unified diff.

--- a/ai_prompts/05_repo_overview.md
+++ b/ai_prompts/05_repo_overview.md
@@ -1,0 +1,1 @@
+Produce a Markdown file DOCS/REPO_OVERVIEW.md that lists every folder/file in TrendSpire and explains its high-level purpose and public functions.

--- a/ai_prompts/06_readme_sync_payload.json
+++ b/ai_prompts/06_readme_sync_payload.json
@@ -1,0 +1,3 @@
+{
+  "prompt": "Create the prompt template that ai-readme-improver needs, then show me the updated README.md it would generate."
+}

--- a/ai_prompts/07_contributing_and_usage_docs.md
+++ b/ai_prompts/07_contributing_and_usage_docs.md
@@ -1,0 +1,1 @@
+Write two standalone markdown files, CONTRIBUTING.md and USAGE.md, with the sections described earlier.

--- a/scripts/run_prompt.py
+++ b/scripts/run_prompt.py
@@ -1,0 +1,70 @@
+"""Utility to run a stored prompt through OpenAI Codex and apply the diff."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.openai_helper import ask_openai
+
+
+def run(prompt_path: Path, branch: str) -> None:
+    prompt_text = prompt_path.read_text(encoding="utf-8")
+    diff = ask_openai(prompt_text)
+
+    history_dir = Path("ai_run_history")
+    history_dir.mkdir(exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    diff_file = history_dir / f"{prompt_path.stem}_{timestamp}.patch"
+    diff_file.write_text(diff, encoding="utf-8")
+
+    patch_path = Path("temp.patch")
+    patch_path.write_text(diff, encoding="utf-8")
+    subprocess.run(["git", "apply", "--index", str(patch_path)], check=True)
+
+    result = subprocess.run(["pytest", "-q"])
+    if result.returncode != 0:
+        subprocess.run(["git", "reset", "--hard", "HEAD"], check=True)
+        raise SystemExit(result.returncode)
+
+    subprocess.run(["git", "config", "user.name", "github-actions[bot]"], check=True)
+    subprocess.run([
+        "git",
+        "config",
+        "user.email",
+        "github-actions[bot]@users.noreply.github.com",
+    ], check=True)
+    subprocess.run(["git", "checkout", "-b", branch], check=True)
+    subprocess.run(["git", "commit", "-am", f"Codex update from {prompt_path.name}"], check=True)
+    subprocess.run(["git", "push", "--set-upstream", "origin", branch], check=True)
+
+    # Return to main for subsequent prompts
+    subprocess.run(["git", "checkout", "main"], check=True)
+
+    if os.getenv("GITHUB_TOKEN"):
+        subprocess.run([
+            "gh",
+            "pr",
+            "create",
+            "--title",
+            f"Codex update {prompt_path.name}",
+            "--body",
+            "Automated update via run_prompt.py",
+            "--base",
+            "main",
+        ], check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a Codex prompt")
+    parser.add_argument("prompt_path", type=Path, help="Path to prompt file")
+    parser.add_argument("branch", help="Name of branch to create")
+    args = parser.parse_args()
+    run(args.prompt_path, args.branch)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ai_prompts/` folder with seven prompt templates
- implement `scripts/run_prompt.py` to apply a prompt, run tests and push a PR
- create workflow `auto_codex_pipeline.yml` that runs all prompts in order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436ac3d0b483308b51fe89031ab928