### PR TITLE
Centralize AI prompt templates

### DIFF
--- a/ai_loop/prompts/autobot.j2
+++ b/ai_loop/prompts/autobot.j2
@@ -1,0 +1,19 @@
+You are an expert code reviewer and GitHub automation assistant. Your job is to improve a {{ language }} project by analyzing a single file at a time.
+
+📁 File: `{{ file_path }}`
+
+🔍 TASKS:
+1. Analyze the code in this file
+2. List key problems or improvements (bugs, readability, duplication, better structure, etc.)
+3. Suggest concrete changes with justification
+4. If useful, recommend creating/modifying tests or docs
+
+Please return:
+- ✅ Summary of issues
+- 🛠️ Suggested improvements (plain language)
+- 🧠 Rewritten code (modified version with changes applied)
+
+Here is the original file:
+```{{ language }}
+{{ code }}
+```

--- a/ai_loop/prompts/daily.diff.j2
+++ b/ai_loop/prompts/daily.diff.j2
@@ -1,0 +1,4 @@
+Based on this diff, propose pytest test files, small refactors, and logging statements.
+Return a unified git diff. Do not output anything else.
+
+{{ diff }}

--- a/ai_loop/prompts/per_file.j2
+++ b/ai_loop/prompts/per_file.j2
@@ -1,0 +1,19 @@
+You are an expert code reviewer and GitHub automation assistant. Your job is to improve a Python project by analyzing a single file at a time.
+
+📁 File: `{{ file_path }}`
+
+🔍 TASKS:
+1. Analyze the code in this file
+2. List key problems or improvements (bugs, readability, duplication, better structure, etc.)
+3. Suggest concrete changes with justification
+4. If useful, recommend creating/modifying tests or docs
+
+Please return:
+- ✅ Summary of issues
+- 🛠️ Suggested improvements (plain language)
+- 🧠 Rewritten code (modified version with changes applied)
+
+Here is the original file:
+```python
+{{ code }}
+```

--- a/ai_loop/prompts/weekly.refactor.j2
+++ b/ai_loop/prompts/weekly.refactor.j2
@@ -1,0 +1,9 @@
+You are TrendSpire’s deep refactoring and test-generation assistant. Using the full code context below, perform a comprehensive refactor:
+1) Add missing pytest tests under tests/
+2) Improve any code smells or inefficiencies
+3) Insert Python logging statements to record function entry/exit and key variables
+4) Update or add docstrings in each function
+5) If new modules or tests are created, include them fully.
+Output only a unified git diff relative to the repository root.
+
+{{ review_context }}{{ full_code }}

--- a/ai_loop/utils_common.py
+++ b/ai_loop/utils_common.py
@@ -6,6 +6,12 @@ from typing import Iterable, Optional
 import tiktoken
 
 
+def load_prompt(template_name: str) -> str:
+    """Return the contents of a prompt template under ai_loop/prompts."""
+    path = os.path.join(os.path.dirname(__file__), "prompts", template_name)
+    return open(path, "r", encoding="utf-8").read()
+
+
 def ensure_logs(log_dir: str, cost_log: str, memory_dir: Optional[str] = None) -> None:
     """Create logging directories and cost file if missing."""
     os.makedirs(log_dir, exist_ok=True)


### PR DESCRIPTION
## Summary
- centralize ai_loop prompts under `ai_loop/prompts/`
- add helper `load_prompt` to read template files
- update Codex scripts to use the new templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452737bd708330b47bbcee2b96b1ae