### PR TITLE
Add smoke tests and CI metrics

### DIFF
--- a/ai_loop/.github/workflows/ai_loop.yml
+++ b/ai_loop/.github/workflows/ai_loop.yml
@@ -7,8 +7,12 @@ on:
     - cron: '0 5 * * *'
   push:
     branches: [main]
+    paths:
+      - 'ai_loop/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'ai_loop/**'
   workflow_dispatch:
     inputs:
       mode:
@@ -113,3 +117,42 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python ai_loop/codex_autobot.py || exit 1
+
+  smoke_test:
+    runs-on: ubuntu-latest
+    needs: [codex_review, autobot]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run smoke tests
+        id: smoke
+        run: |
+          python ai_loop/trendspire_autoloop.py --help
+          auto_exit=$?
+          python ai_loop/codex_autobot.py --help
+          autobot_exit=$?
+          if [ "$auto_exit" -ne 0 ] || [ "$autobot_exit" -ne 0 ]; then
+            exit 1
+          fi
+          echo "auto_exit=$auto_exit" >> "$GITHUB_OUTPUT"
+          echo "autobot_exit=$autobot_exit" >> "$GITHUB_OUTPUT"
+      - name: Log CI run metrics
+        if: success()
+        run: |
+          mkdir -p ai_loop/metrics
+          if [ ! -f ai_loop/metrics/ci_runs.csv ]; then
+            echo "timestamp,agent,exit_code" > ai_loop/metrics/ci_runs.csv
+          fi
+          ts=$(date --iso-8601=seconds)
+          echo "$ts,trendspire_autoloop,${{ steps.smoke.outputs.auto_exit }}" >> ai_loop/metrics/ci_runs.csv
+          echo "$ts,codex_autobot,${{ steps.smoke.outputs.autobot_exit }}" >> ai_loop/metrics/ci_runs.csv

--- a/ai_loop/metrics/ci_runs.csv
+++ b/ai_loop/metrics/ci_runs.csv
@@ -1,0 +1,1 @@
+timestamp,agent,exit_code


### PR DESCRIPTION
## Summary
- trigger ai_loop workflow only when ai_loop/* files change
- add smoke test job for `trendspire_autoloop.py` and `codex_autobot.py`
- record CI runs under `ai_loop/metrics/ci_runs.csv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452cb49c3c83308e96bec289911f74