### PR TITLE
Implement Phase 2.2 AI context and suggestion flow

### DIFF
--- a/ai_loop/agent_loop.py
+++ b/ai_loop/agent_loop.py
@@ -1,20 +1,22 @@
 """Minimal agent pipeline orchestration."""
 
-from .context_builder import build_context
-from .agents import run_planner, run_coder, run_pr_agent
+from . import context_builder, suggestor
+from .agents import pr_agent
 
 
 def run() -> str:
-    """Execute the Planner → Coder → PR Agent pipeline."""
-    print("[AgentLoop] Building context")
-    context = build_context()
+    """Execute context loading, patch suggestion and PR formatting."""
+    print("[AgentLoop] Loading context")
+    context = context_builder.load_context()
 
-    plan = run_planner(context)
-    diff = run_coder(plan)
-    pr_message = run_pr_agent(diff)
+    print("[AgentLoop] Requesting patch suggestion")
+    diff = suggestor.suggest_patch(context)
+
+    print("[AgentLoop] Formatting PR")
+    pr_message = pr_agent.format_pr(diff)
 
     print("[AgentLoop] Pipeline complete")
-    print("Phase 2.1 complete: Agent pipeline scaffolded.")
+    print("✅ Phase 2.2 complete: AI suggestion generated.")
     return pr_message
 
 

--- a/ai_loop/agents/pr_agent.py
+++ b/ai_loop/agents/pr_agent.py
@@ -1,12 +1,15 @@
-"""Placeholder PR formatting agent."""
+"""Pull request formatting agent."""
 
 
-def run(diff: str) -> str:
-    """Return a dummy PR body for the given diff."""
-    print("[PR Agent] Formatting PR message")
+def format_pr(diff: str) -> str:
+    """Return a simple PR body for the given diff."""
     pr_body = (
         "### Proposed Changes\n\n"
-        "This PR includes the following dummy diff:\n\n"
-        f"```diff\n{diff}\n```"
+        f"```diff\n{diff}\n```\n"
     )
     return pr_body
+
+
+def run(diff: str) -> str:  # pragma: no cover - legacy alias
+    print("[PR Agent] Formatting PR message")
+    return format_pr(diff)

--- a/ai_loop/context_builder.py
+++ b/ai_loop/context_builder.py
@@ -1,10 +1,66 @@
-"""Gather context for the AI loop.
+"""Gather high-level repository context for the AI-loop."""
 
-Future implementations will collect file contents, digests, and other
-information used to generate prompts.
-"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
 
 
-def build_context() -> dict:
-    """Return placeholder context data."""
-    return {}
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def _summarize(text: str, lines: int = 20) -> str:
+    return "\n".join(text.splitlines()[:lines])
+
+
+def _src_summary() -> str:
+    src = REPO_ROOT / "src"
+    if not src.is_dir():
+        return ""
+    names = sorted(p.name for p in src.iterdir())
+    return ", ".join(names)
+
+
+def _latest_trend_summary() -> str:
+    archive = REPO_ROOT / "trends" / "archive"
+    json_files = list(archive.glob("*.json"))
+    if not json_files:
+        return ""
+    latest = max(json_files)
+    try:
+        data = json.loads(latest.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    parts = [data.get("timestamp", "")]
+    for repo in data.get("repos", [])[:5]:
+        parts.append(f"{repo.get('name')} ({repo.get('stars')})")
+    return "; ".join(parts)
+
+
+def load_context() -> dict:
+    """Return repository context used for prompting."""
+    readme = _read_text(REPO_ROOT / "README.md")
+    goals = _read_text(REPO_ROOT / "GOALS.md")
+    trending_md = _summarize(_read_text(REPO_ROOT / "TRENDING.md"))
+    src_summary = _src_summary()
+    trend_json_summary = _latest_trend_summary()
+
+    return {
+        "readme": readme,
+        "src_summary": src_summary,
+        "trending_md": trending_md,
+        "trend_json_summary": trend_json_summary,
+        "goals": goals,
+    }
+
+
+# Backwards compatibility
+def build_context() -> dict:  # pragma: no cover - legacy alias
+    return load_context()

--- a/ai_loop/logger.py
+++ b/ai_loop/logger.py
@@ -1,7 +1,36 @@
-"""Record token usage and results for AI loop runs."""
+"""Utilities for logging OpenAI usage and prompts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parent / "codex_logs"
+LOG_DIR.mkdir(exist_ok=True)
 
 
-def log_result(*, tokens: int = 0, cost: float = 0.0, notes: str = "") -> None:
-    """Placeholder for future logging implementation."""
-    # TODO: write log entries to /codex_logs/
-    pass
+def log_result(
+    prompt: str,
+    response: str,
+    *,
+    prompt_tokens: int,
+    completion_tokens: int,
+    cost: float,
+) -> None:
+    """Write a log entry containing prompt, response and cost data."""
+    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    log_path = LOG_DIR / f"log_{timestamp}.txt"
+    max_len = 2000
+
+    def _truncate(text: str) -> str:
+        return text[:max_len] + ("\n...[truncated]" if len(text) > max_len else "")
+
+    with open(log_path, "w", encoding="utf-8") as fh:
+        fh.write(f"timestamp: {timestamp}\n")
+        fh.write(f"prompt_tokens: {prompt_tokens}\n")
+        fh.write(f"completion_tokens: {completion_tokens}\n")
+        fh.write(f"total_cost: {cost:.6f}\n")
+        fh.write("prompt:\n")
+        fh.write(_truncate(prompt) + "\n")
+        fh.write("response:\n")
+        fh.write(_truncate(response) + "\n")

--- a/ai_loop/suggestor.py
+++ b/ai_loop/suggestor.py
@@ -1,12 +1,68 @@
-"""OpenAI prompt generation and API helpers."""
+"""OpenAI prompt generation and request helpers."""
+
+from __future__ import annotations
+
+import os
+from openai import OpenAI, OpenAIError
+
+from .logger import log_result
+
+DEFAULT_MODEL = "gpt-4o"
+MODEL_PRICES = {
+    "gpt-4o": (0.005, 0.015),  # prompt, completion per 1K tokens
+    "gpt-4": (0.03, 0.06),
+}
 
 
 def create_prompt(context: dict) -> str:
-    """Return a placeholder prompt string."""
-    return ""
+    """Format repository context into a single prompt string."""
+    sections = [
+        "You are an autonomous developer assistant. "
+        "Suggest one small improvement to the repository below. "
+        "Respond only with a unified diff.",
+        "\n\n# README\n" + context.get("readme", ""),
+        "\n\n# Source Summary\n" + context.get("src_summary", ""),
+        "\n\n# Trending Digest\n" + context.get("trending_md", ""),
+        "\n\n# Latest Trend Snapshot\n" + context.get("trend_json_summary", ""),
+        "\n\n# Goals\n" + context.get("goals", ""),
+    ]
+    return "\n".join(sections)
 
 
-def request_suggestion(prompt: str) -> str:
-    """Send the prompt to OpenAI (not yet implemented)."""
-    # TODO: integrate OpenAI client in Phase 2
-    return ""
+def request_suggestion(prompt: str, model: str = DEFAULT_MODEL) -> str:
+    """Send the prompt to OpenAI and return the diff text."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set in environment")
+
+    client = OpenAI(api_key=api_key)
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except OpenAIError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    content = resp.choices[0].message.content
+    usage = resp.usage
+    prompt_tokens = getattr(usage, "prompt_tokens", 0)
+    completion_tokens = getattr(usage, "completion_tokens", 0)
+    price = MODEL_PRICES.get(model, (0.0, 0.0))
+    cost = (prompt_tokens / 1000 * price[0]) + (completion_tokens / 1000 * price[1])
+
+    log_result(
+        prompt,
+        content,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        cost=cost,
+    )
+
+    return content
+
+
+def suggest_patch(context: dict, model: str = DEFAULT_MODEL) -> str:
+    """High-level helper that builds the prompt and returns the diff."""
+    prompt = create_prompt(context)
+    return request_suggestion(prompt, model=model)


### PR DESCRIPTION
## Summary
- implement `load_context` in `context_builder`
- add OpenAI prompt logic and request handling in `suggestor`
- log prompts and responses via updated `logger`
- use real context → diff → PR flow in `agent_loop`
- provide simple `format_pr` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a0c730148330962df08e4e5a8a0e