### PR TITLE
Implement Phase 3 sanity checks and planning improvements

### DIFF
--- a/ai_loop/AGENTS.md
+++ b/ai_loop/AGENTS.md
@@ -72,5 +72,6 @@ python ai_loop/codex_autobot.py
 ## Next Steps
 Phase 2.3 added memory context and Phase 2.4 ensures graceful fallback if the
 memory file is missing or the OpenAI call fails. Phase 2.5 introduced basic unit
-tests for the agent loop and context builder.
+tests for the agent loop and context builder. Phase 3 expands the agents with
+sanity checks and multiple planning options.
 Phase 2 is now complete.

--- a/ai_loop/GOALS.md
+++ b/ai_loop/GOALS.md
@@ -35,4 +35,8 @@ request fails.
 Unit tests now cover `agent_loop.run()` and `context_builder.load_context()` to
 ensure memory is included when available and ignored when missing.
 
-Future phases (3‑5) will expand multi‑step reasoning, trend analysis and automated pull requests.
+## ✅ Phase 3.0 – Patch Quality Checks
+Sanity checks reject empty diffs and the planner can return multiple plan options
+for the coder to consider.
+
+Future phases (4‑5) will expand multi‑step reasoning, trend analysis and automated pull requests.

--- a/ai_loop/README.md
+++ b/ai_loop/README.md
@@ -23,6 +23,12 @@ For targeted cleanups you can run the autobot:
 python ai_loop/codex_autobot.py
 ```
 
+## Phase 3 improvements
+
+The planner now returns multiple plan options and the coder performs
+basic sanity checks on generated diffs. Invalid or empty patches are
+rejected and replaced with a safe fallback.
+
 ## Testing modules
 
 Unit tests live under `ai_loop/tests/`. Execute a single module's tests with:

--- a/ai_loop/agent_loop.py
+++ b/ai_loop/agent_loop.py
@@ -13,6 +13,7 @@ def run() -> str:
 
     print("[AgentLoop] Planning")
     plan = run_planner(context)
+    print(f"[AgentLoop] Planner returned {len(plan)} plan(s)")
 
     print("[AgentLoop] Coding")
     diff = run_coder(plan, context)
@@ -21,7 +22,7 @@ def run() -> str:
     pr_message = pr_agent.format_pr(diff)
 
     print("[AgentLoop] Pipeline complete")
-    print("✅ Phase 2.3 complete: PR message ready.")
+    print("✅ Phase 3.0 complete: PR message ready.")
     return pr_message
 
 

--- a/ai_loop/agents/coder.py
+++ b/ai_loop/agents/coder.py
@@ -1,5 +1,7 @@
 """Coding agent that turns a plan into a patch diff."""
 
+from __future__ import annotations
+
 from .. import suggestor
 
 
@@ -15,14 +17,35 @@ def _fallback_diff() -> str:
     )
 
 
-def run(plan: list[str], context: dict | None = None) -> str:
+def _diff_has_change(diff: str) -> bool:
+    for line in diff.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+") or line.startswith("-"):
+            return True
+    return False
+
+
+def run(plan: list[list[str]] | list[str], context: dict | None = None) -> str:
     """Return a diff using `suggestor.suggest_patch` if possible."""
     print("[Coder] Received plan:", plan)
+    if not plan:
+        print("[Coder] Empty plan provided")
+        return _fallback_diff()
+
+    if isinstance(plan[0], list):
+        chosen = plan[0]
+    else:
+        chosen = plan
+    print("[Coder] Using plan steps:", chosen)
+
     if context is not None:
         try:
             diff = suggestor.suggest_patch(context)
             print("[Coder] Generated diff via suggestor")
-            return diff
+            if _diff_has_change(diff):
+                return diff
+            print("[Coder] Diff lacked substantive changes")
         except Exception as exc:  # pragma: no cover - network failure
             print("[Coder] Suggestor failed:", exc)
 

--- a/ai_loop/agents/planner.py
+++ b/ai_loop/agents/planner.py
@@ -1,4 +1,6 @@
-"""Simple planning agent."""
+"""Simple planning agent with lightweight reasoning."""
+
+from __future__ import annotations
 
 from pathlib import Path
 
@@ -6,19 +8,46 @@ from pathlib import Path
 GOALS_FILE = Path(__file__).resolve().parents[2] / "GOALS.md"
 
 
-def run(context: dict | None = None) -> list[str]:
-    """Return a list of planned steps based on GOALS.md and context."""
+def _base_plan(target: str) -> list[str]:
+    return [
+        f"Review {target} for possible improvements",
+        "Call coder agent to draft a patch",
+        "Format pull request message",
+    ]
+
+
+def run(context: dict | None = None) -> list[list[str]]:
+    """Return multiple plan options based on GOALS.md and context."""
     print("[Planner] Reading project goals...")
     try:
         goals_text = GOALS_FILE.read_text(encoding="utf-8")
     except FileNotFoundError:
         goals_text = ""
-    print("[Planner] Creating simple plan from goals and context")
-    plan = [
-        "Read repository context",
-        "Call coder agent to draft a patch",
-        "Format pull request message",
-    ]
+
+    print("[Planner] Creating plan options")
+
+    src_files: list[str] = []
     if context:
-        plan.append("Context size: " + str(len(context.get('readme', ''))))
-    return plan
+        src_summary = context.get("src_summary", "")
+        if src_summary:
+            src_files = [p.strip() for p in src_summary.split(",") if p.strip()]
+
+    primary = src_files[0] if src_files else "README.md"
+    plans = [_base_plan(primary)]
+
+    # Alternate plan references tests and docs for broader coverage
+    alt_plan = [
+        "Check ai_loop/tests for missing coverage",
+        f"Update documentation referencing {primary}",
+        "Call coder agent to draft a patch",
+    ]
+    plans.append(alt_plan)
+
+    if "Phase 3" in goals_text:
+        plans.append([
+            "Implement Phase 3 tasks described in GOALS.md",
+            "Run coder agent to apply sanity checks",
+            "Update project roadmap",
+        ])
+
+    return plans

--- a/ai_loop/tests/test_planner_coder.py
+++ b/ai_loop/tests/test_planner_coder.py
@@ -1,0 +1,16 @@
+from ai_loop.agents import planner, coder
+
+
+def test_planner_multiple_plans():
+    ctx = {"src_summary": "a.py, b.py"}
+    plans = planner.run(ctx)
+    assert isinstance(plans, list)
+    assert len(plans) >= 2
+    assert all(isinstance(p, list) for p in plans)
+
+
+def test_coder_rejects_empty_diff(monkeypatch):
+    plan = [["step"]]
+    monkeypatch.setattr("ai_loop.suggestor.suggest_patch", lambda ctx: "diff --git a/x b/x\n")
+    diff = coder.run(plan, {})
+    assert "+Placeholder content" in diff


### PR DESCRIPTION
## Summary
- improve planner to generate multiple plan options using repository context
- add diff sanity checks in the coder agent
- show number of plans in the agent loop and mark Phase 3 completion
- document Phase 3 behaviour in README and AGENTS
- record Phase 3.0 completion in GOALS
- test planner multi-plan logic and coder diff validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b2c01e4c83309ad8a5c733758af5