### PR TITLE
Add sanity checker agent

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -83,7 +83,7 @@ Upgrades:
 - Each agent step logs output in `ai_loop/codex_logs/`
 - Reviewer comments appear in the PR body
 
-### 📝 Phase 3.2 – Sanity Checker Agent (TODO)
+### ✅ Phase 3.2 – Sanity Checker Agent (Complete)
 - Validate diffs before PR creation and flag obvious issues
 
 ---

--- a/ai_loop/agent_loop.py
+++ b/ai_loop/agent_loop.py
@@ -8,6 +8,7 @@ from . import context_builder
 from .context_builder import MEMORY_CONTEXT
 import json
 from .agents import run_planner, run_coder, pr_agent, review_patch
+from .sanity_checker import sanity_check_diff
 from .logger import LOG_DIR
 
 
@@ -66,6 +67,14 @@ def run() -> str:
     print(f"[Reviewer] Approved: {review.get('approved')}\n[Reviewer] Comments: {review.get('comments')}")
     _log_step("review", str(review))
 
+    print("[AgentLoop] Sanity checking")
+    is_safe, reasons = sanity_check_diff(diff)
+    _log_step("sanity", str({"safe": is_safe, "reasons": reasons}))
+    if not is_safe:
+        message = "Sanity check failed: " + "; ".join(reasons)
+        print(f"[AgentLoop] {message}")
+        return message
+
     print("[AgentLoop] Formatting PR")
     pr_message = pr_agent.format_pr(diff)
     if review.get("comments"):
@@ -73,7 +82,7 @@ def run() -> str:
     _log_step("pr", pr_message)
 
     print("[AgentLoop] Pipeline complete")
-    print("✅ Phase 3.1 complete: PR message ready.")
+    print("✅ Phase 3.2 complete: PR message ready.")
     return pr_message
 
 

--- a/ai_loop/sanity_checker.py
+++ b/ai_loop/sanity_checker.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import re
+from typing import List, Tuple
+
+from .utils_common import is_valid_diff, is_suspicious_deletion, call_openai_chat
+
+
+SYSTEM_PROMPT = (
+    "You're a sanity checker for code patches. Given the following diff, "
+    "is it safe and valid to apply? Flag any dangerous or suspicious changes."
+)
+
+
+def _llm_safety_check(diff: str) -> list[str]:
+    """Optionally ask OpenAI to flag issues. Returns list of concerns."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return []
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": diff},
+    ]
+    try:
+        response, *_ = call_openai_chat(messages)
+        text = response.lower()
+        if any(word in text for word in ["danger", "suspicious", "malicious"]):
+            return [response.strip()]
+    except Exception:
+        return []
+    return []
+
+
+def sanity_check_diff(diff: str) -> Tuple[bool, List[str]]:
+    """Return (is_safe, reasons)."""
+    reasons: list[str] = []
+
+    if not diff.strip():
+        reasons.append("Diff is empty")
+        return False, reasons
+
+    if not is_valid_diff(diff):
+        reasons.append("Invalid unified diff format")
+
+    if is_suspicious_deletion(diff):
+        reasons.append("Diff deletes entire files")
+
+    if re.search(r"rm\s+-rf", diff):
+        reasons.append("Contains 'rm -rf' command")
+
+    deletions = sum(
+        1
+        for line in diff.splitlines()
+        if line.startswith("-") and not line.startswith("---")
+    )
+    if deletions > 100:
+        reasons.append("Excessive deletions")
+
+    reasons.extend(_llm_safety_check(diff))
+
+    return len(reasons) == 0, reasons

--- a/ai_loop/tests/test_sanity_checker.py
+++ b/ai_loop/tests/test_sanity_checker.py
@@ -1,0 +1,31 @@
+from ai_loop import sanity_checker
+
+
+def test_sanity_all_good():
+    diff = """diff --git a/x b/x
+--- a/x
++++ b/x
+@@
++hello
+"""
+    safe, reasons = sanity_checker.sanity_check_diff(diff)
+    assert safe
+    assert reasons == []
+
+
+def test_sanity_flags_rm_rf():
+    diff = """diff --git a/x b/x
+--- a/x
++++ b/x
+@@
++rm -rf /tmp
+"""
+    safe, reasons = sanity_checker.sanity_check_diff(diff)
+    assert not safe
+    assert any("rm -rf" in r for r in reasons)
+
+
+def test_sanity_invalid_diff():
+    safe, reasons = sanity_checker.sanity_check_diff("no diff here")
+    assert not safe
+    assert "Invalid" in reasons[0] or reasons


### PR DESCRIPTION
## Summary
- implement `sanity_checker.py` to validate diffs
- integrate sanity check into `agent_loop`
- mark Phase 3.2 complete in `GOALS.md`
- test sanity checker behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c0cc36cc8330a20682a308170356