### PR TITLE
📊 Add run loop and cost tracking

### DIFF
--- a/ai_loop/logger.py
+++ b/ai_loop/logger.py
@@ -8,6 +8,11 @@ from pathlib import Path
 LOG_DIR = Path(__file__).resolve().parent / "codex_logs"
 LOG_DIR.mkdir(exist_ok=True)
 
+# cost tracking file under memory/
+MEMORY_DIR = Path(__file__).resolve().parents[1] / "memory"
+COST_TRACKER = MEMORY_DIR / "cost_tracker.csv"
+MEMORY_DIR.mkdir(exist_ok=True)
+
 
 def log_result(
     prompt: str,
@@ -17,7 +22,7 @@ def log_result(
     completion_tokens: int,
     cost: float,
 ) -> None:
-    """Write a log entry containing prompt, response and cost data."""
+    """Write a log entry and track token costs."""
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
     log_path = LOG_DIR / f"log_{timestamp}.txt"
     max_len = 2000
@@ -34,3 +39,10 @@ def log_result(
         fh.write(_truncate(prompt) + "\n")
         fh.write("response:\n")
         fh.write(_truncate(response) + "\n")
+
+    # Append cost tracking row
+    write_header = not COST_TRACKER.exists()
+    with open(COST_TRACKER, "a", encoding="utf-8") as f:
+        if write_header:
+            f.write("timestamp,prompt_tokens,completion_tokens,cost_usd\n")
+        f.write(f"{timestamp},{prompt_tokens},{completion_tokens},{cost:.6f}\n")

--- a/ai_loop/tests/test_logging.py
+++ b/ai_loop/tests/test_logging.py
@@ -15,3 +15,21 @@ def test_ensure_logs_creates_files(tmp_path, monkeypatch):
     assert (tmp_path / 'logs').is_dir()
     assert (tmp_path / 'mem').is_dir()
     assert (tmp_path / 'costs.csv').is_file()
+
+import importlib.util
+
+
+def test_log_result_tracks_cost(tmp_path, monkeypatch):
+    module_path = repo_root / 'ai_loop' / 'logger.py'
+    spec = importlib.util.spec_from_file_location('logger', module_path)
+    logger = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(logger)
+    monkeypatch.setattr(logger, 'LOG_DIR', tmp_path / 'logs')
+    monkeypatch.setattr(logger, 'MEMORY_DIR', tmp_path / 'mem')
+    monkeypatch.setattr(logger, 'COST_TRACKER', tmp_path / 'mem' / 'cost.csv')
+    logger.LOG_DIR.mkdir()
+    logger.MEMORY_DIR.mkdir()
+    logger.log_result('p', 'r', prompt_tokens=1, completion_tokens=2, cost=0.5)
+    rows = logger.COST_TRACKER.read_text().splitlines()
+    assert rows[0].startswith('timestamp')
+    assert len(rows) == 2

--- a/memory/cost_tracker.csv
+++ b/memory/cost_tracker.csv
@@ -1,0 +1,1 @@
+timestamp,prompt_tokens,completion_tokens,cost_usd

--- a/run_loop.py
+++ b/run_loop.py
@@ -1,0 +1,54 @@
+"""Main AI patch cycle runner for TrendSpire."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ai_loop import context_builder
+from ai_loop.agents import run_planner, run_coder, review_patch, pr_agent
+from ai_loop.sanity_checker import sanity_check_diff
+from ai_loop.utils_common import run_cmd
+
+LOG_DIR = Path("ai_loop/codex_logs")
+LOG_DIR.mkdir(exist_ok=True)
+
+
+def apply_patch(diff: str) -> None:
+    """Apply a unified diff using git."""
+    patch_path = LOG_DIR / "latest.patch"
+    patch_path.write_text(diff, encoding="utf-8")
+    run_cmd(["git", "apply", str(patch_path)])
+
+
+def main() -> None:
+    """Execute planner → coder → reviewer → patch workflow."""
+    context = context_builder.load_context()
+    plan = run_planner(context)
+    diff = run_coder(plan, context)
+
+    review = review_patch(diff, context)
+    safe, reasons = sanity_check_diff(diff)
+
+    if not safe:
+        print("[run_loop] Diff rejected:", "; ".join(reasons))
+        return
+    if not review.get("approved", True):
+        print("[run_loop] Reviewer rejected diff.")
+        return
+
+    apply_patch(diff)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    branch = f"ai-patch-{timestamp}"
+    run_cmd(["git", "checkout", "-b", branch])
+    run_cmd(["git", "add", "-A"])
+    run_cmd(["git", "commit", "-m", f"AI patch {timestamp}"])
+
+    pr_message = pr_agent.format_pr(diff)
+    (LOG_DIR / f"pr_{timestamp}.md").write_text(pr_message, encoding="utf-8")
+    print(pr_message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `run_loop.py` to run planner, coder, reviewer and apply patches
- extend logger to track token usage in `memory/cost_tracker.csv`
- add tests for new logging behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d6db83e08330874f0c15abf3b3f5